### PR TITLE
Ppp cpi solution

### DIFF
--- a/00_master.R
+++ b/00_master.R
@@ -144,11 +144,10 @@ Means_pipeline_sac <- function(cache_inventory,
                                                     pfw_table = dl_aux$pfw)
   
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ## Means in PPP --------
+  ## Means in PPP and other changes --------
   
-  svy_mean_ppp_table_sac <- db_create_dsm_table_sac(lcu_table = svy_mean_lcu_table_sac,
-                                                    cpi_table = dl_aux$cpi,
-                                                    ppp_table = dl_aux$ppp)
+  svy_mean_ppp_table_sac <- db_create_dsm_table_sac(lcu_table = svy_mean_lcu_table_sac)
+  
   return(svy_mean_ppp_table_sac)
 }
 
@@ -211,6 +210,28 @@ all.equal(means_out_tar,compare_sac)
 waldo::compare(means_out_tar,compare_sac, tolerance = 1e-7)
 
 rm(compare_sac)
+
+# Filter without survey_mean_ppp, cpi and ppp
+compare_sac <- means_out_sac[, -c("survey_mean_ppp","ppp","cpi")]
+compare_tar <- means_out_tar[, -c("survey_mean_ppp","ppp","cpi")]
+
+# Eliminate attributes 
+compare_sac <- as.data.table(lapply(compare_sac, function(x) { attributes(x) <- NULL; return(x) }))
+
+# Order rows
+data.table::setorder(compare_sac, survey_id, cache_id, reporting_level,ppp_data_level)
+data.table::setorder(compare_tar, survey_id, cache_id,reporting_level, ppp_data_level)
+
+# Order columns
+compare_sac <- compare_sac[, colnames(compare_tar), with = FALSE]
+
+# Comparison
+all.equal(compare_tar,compare_sac)
+
+waldo::compare(compare_tar,compare_sac, tolerance = 1e-7)
+
+rm(compare_sac,compare_tar)
+
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # 3. Dist Stats   ---------
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/00_master.R
+++ b/00_master.R
@@ -287,7 +287,8 @@ Dist_stats_tar <- function(cache,
 
 # Load output:
 dist_out_sac <- Dist_stats_sac(cache = cache_sac, 
-                               dsm_table = means_out_sac)
+                               dsm_table = means_out_sac,
+                               cache_inventory = cache_inventory)
 
 dist_out_tar <- Dist_stats_tar(cache = cache_ls,
                                dsm_table = means_out_tar, 

--- a/Functions_SAC.R
+++ b/Functions_SAC.R
@@ -558,51 +558,16 @@ db_dist_stats_sac <- function(cache,
   
   # 2. Micro Data: Level Estimation  ----
   
-  md_level <- dt_m |>
+  md_id_level <- dt_m |>
     fsubset(distribution_type %in% c("micro")) |>
     fselect(-c(distribution_type))|>
     roworder(cache_id, pop_data_level, welfare_ppp) |>
-    collapse::join(mean_table |> 
-                     fselect(cache_id, cpi_data_level, ppp_data_level,
-                             gdp_data_level, pce_data_level,
-                             pop_data_level, reporting_level, 
-                             survey_mean_ppp, reporting_pop),
-                   on=c("cache_id", "cpi_data_level", "ppp_data_level",
-                        "gdp_data_level", "pce_data_level",
-                        "pop_data_level", "reporting_level"), 
-                   # GC Note: it is actually over-identified at this stage. 
-                   # Maybe we can exlpore whether this is really needed?
-                   validate = "m:1",
-                   verbose = 0,
-                   overid = 2,
-                   column = list(".joyn", c("x", "y", "x & y")))|>
-    _[, as.list(wrp_md_dist_stats(welfare = welfare_ppp,
-                                  weight  = weight,
-                                  mean = funique(survey_mean_ppp))),
-      by = .(cache_id, cpi_data_level, ppp_data_level,
-             gdp_data_level, pce_data_level,
-             pop_data_level, reporting_level)]|>
-    fungroup()|>
-    frename(survey_median_ppp = median)|>
-    fmutate(reporting_level = as.character(reporting_level),
-            pop_data_level = as.character(pop_data_level)) |>
-    fselect(-c(cpi_data_level, ppp_data_level,
-               gdp_data_level, pce_data_level)) # 3 minutes
-  
-  
-  # 3. Imputed Data: Level Estimation  ----
-  
-  id_level <- dt_m |>
-    fsubset(distribution_type %in% c("imputed")) |>
-    fselect(-c(distribution_type))|>
     _[, as.list(wrp_md_dist_stats(welfare = welfare_ppp,
                                   weight  = weight,
                                   mean = NULL)),
-      # Note: Here we remove area from the grouping too, and we add the other levels:
       by = .(cache_id, imputation_id, cpi_data_level, ppp_data_level,
              gdp_data_level, pce_data_level,
              pop_data_level, reporting_level)]|>
-    # Note: and here again, area out, other levels in:
     fgroup_by(cache_id, cpi_data_level, ppp_data_level,
               gdp_data_level, pce_data_level,
               pop_data_level, reporting_level)|>
@@ -614,9 +579,10 @@ db_dist_stats_sac <- function(cache,
     fmutate(reporting_level = as.character(reporting_level),
             pop_data_level = as.character(pop_data_level))|>
     fselect(-c(cpi_data_level, ppp_data_level,
-               gdp_data_level, pce_data_level)) # < 1 minute
+               gdp_data_level, pce_data_level))
   
-  # 4. Micro and Imputed Data: National Estimation ----
+  
+  # 3. Micro and Imputed Data: National Estimation ----
   
   md_id_national <- dt_m |>
     # Gc Note: this is equivalent to having pop_data_level > 1 and D2 in cache_id:
@@ -685,7 +651,7 @@ db_dist_stats_sac <- function(cache,
     
     setrename(gd_ag_level, gsub("deciles", "decile", names(gd_ag_level)))
     
-    # 5. Aggregate Data: National estimation (synth needed) ----
+    # 4. Aggregate Data: National estimation (synth needed) ----
     
     ag_syn <- dt_jn |>
       fsubset(distribution_type %in% c("aggregate")) |>
@@ -718,7 +684,7 @@ db_dist_stats_sac <- function(cache,
       fmutate(reporting_level = as.character("national"),
               pop_data_level = as.character("national")) # immediate
     
-    # 6. Row bind and return ----
+    # 5. Row bind and return ----
     
     final <- rowbind(md_level, id_level, md_id_national, gd_ag_level, ag_national)
     

--- a/Functions_SAC.R
+++ b/Functions_SAC.R
@@ -497,29 +497,14 @@ db_dist_stats_sac <- function(cache,
   dt_m <- cache |>
     fselect(cache_id, distribution_type, cpi_data_level, ppp_data_level,
             gdp_data_level, pce_data_level,
-            pop_data_level, reporting_level, 
+            pop_data_level, reporting_level,
             imputation_id, weight, welfare_ppp)|>
     fsubset(distribution_type %in% c("micro", "imputed"))
   
   # 2. Micro Data: Level Estimation  ----
   
-  md_level <- dt_m |>
-    fsubset(distribution_type %in% c("micro"))|>
+  md_id_level <- dt_m |>
     roworder(cache_id, pop_data_level, welfare_ppp) |>
-    _[, as.list(wrp_md_dist_stats(welfare = welfare_ppp,
-                                  weight  = weight,
-                                  mean = NULL)),
-      by = .(cache_id, cpi_data_level, ppp_data_level,
-             gdp_data_level, pce_data_level,
-             pop_data_level, reporting_level)]|>
-    frename(survey_median_ppp = median)|>
-    fmutate(reporting_level = as.character(reporting_level),
-            pop_data_level = as.character(pop_data_level)) |>
-    fselect(-c(cpi_data_level, ppp_data_level,
-               gdp_data_level, pce_data_level))
-  
-  id_level <- dt_m |>
-    fsubset(distribution_type %in% c("imputed")) |>
     _[, as.list(wrp_md_dist_stats(welfare = welfare_ppp,
                                   weight  = weight,
                                   mean = NULL)),
@@ -641,13 +626,13 @@ db_dist_stats_sac <- function(cache,
     
     # 5. Row bind and return ----
     
-    final <- rowbind(md_level, id_level, md_id_national, gd_ag_level, ag_national)
+    final <- rowbind(md_id_level, md_id_national, gd_ag_level, ag_national)
     
     return(final)
     
   }
-  
-  final <- rowbind(md_level, id_level, md_id_national)
+
+  final <- rowbind(md_id_level, md_id_national)
   
   return(final)
   

--- a/Functions_SAC.R
+++ b/Functions_SAC.R
@@ -686,13 +686,13 @@ db_dist_stats_sac <- function(cache,
     
     # 5. Row bind and return ----
     
-    final <- rowbind(md_level, id_level, md_id_national, gd_ag_level, ag_national)
+    final <- rowbind(md_id_level, md_id_national, gd_ag_level, ag_national)
     
     return(final)
     
   }
   
-  final <- rowbind(md_level, id_level, md_id_national)
+  final <- rowbind(md_id_level, md_id_national)
   
   return(final)
   

--- a/Functions_SAC.R
+++ b/Functions_SAC.R
@@ -498,13 +498,28 @@ db_dist_stats_sac <- function(cache,
     fselect(cache_id, distribution_type, cpi_data_level, ppp_data_level,
             gdp_data_level, pce_data_level,
             pop_data_level, reporting_level, 
-            imputation_id, weight, welfare_ppp) |>
+            imputation_id, weight, welfare_ppp)|>
     fsubset(distribution_type %in% c("micro", "imputed"))
   
   # 2. Micro Data: Level Estimation  ----
   
-  md_id_level <- dt_m |>
+  md_level <- dt_m |>
+    fsubset(distribution_type %in% c("micro"))|>
     roworder(cache_id, pop_data_level, welfare_ppp) |>
+    _[, as.list(wrp_md_dist_stats(welfare = welfare_ppp,
+                                  weight  = weight,
+                                  mean = NULL)),
+      by = .(cache_id, cpi_data_level, ppp_data_level,
+             gdp_data_level, pce_data_level,
+             pop_data_level, reporting_level)]|>
+    frename(survey_median_ppp = median)|>
+    fmutate(reporting_level = as.character(reporting_level),
+            pop_data_level = as.character(pop_data_level)) |>
+    fselect(-c(cpi_data_level, ppp_data_level,
+               gdp_data_level, pce_data_level))
+  
+  id_level <- dt_m |>
+    fsubset(distribution_type %in% c("imputed")) |>
     _[, as.list(wrp_md_dist_stats(welfare = welfare_ppp,
                                   weight  = weight,
                                   mean = NULL)),
@@ -626,13 +641,13 @@ db_dist_stats_sac <- function(cache,
     
     # 5. Row bind and return ----
     
-    final <- rowbind(md_id_level, md_id_national, gd_ag_level, ag_national)
+    final <- rowbind(md_level, id_level, md_id_national, gd_ag_level, ag_national)
     
     return(final)
     
   }
   
-  final <- rowbind(md_id_level, md_id_national)
+  final <- rowbind(md_level, id_level, md_id_national)
   
   return(final)
   

--- a/replex_welfare_ppp.qmd
+++ b/replex_welfare_ppp.qmd
@@ -264,7 +264,7 @@ waldo::compare(dt_tst$welfare_ppp, dt_tst$new_welf_ppp)
 
 ```
 
-3.  Check if it works using the new `welfare_ppp` vector.
+Check if it works using the new `welfare_ppp` vector.
 
 ```{r}
 
@@ -294,4 +294,96 @@ md_level_idn <- dt_tst[, as.list(wrp_md_dist_stats(welfare = new_welf_ppp,
 
 waldo::compare(md_level_idn$mean, md_level_idn$survey_mean_ppp, tolerance = 1e-6)
 
+```
+
+3. Test if we need to round out `survey_year`
+
+```{r}
+
+data_idn <- cache_tb|>
+  fsubset(country_code == "IDN" & distribution_type %in% c("imputed", "micro"))|>
+  fselect(welfare, welfare_ppp, welfare_lcu,
+          weight, survey_id, cache_id, country_code, 
+          surveyid_year, survey_acronym, survey_year, welfare_type,
+          distribution_type, gd_type, imputation_id, cpi_data_level, 
+          ppp_data_level, gdp_data_level, pce_data_level, 
+          pop_data_level, reporting_level)|>
+  ftransform(survey_year = round(survey_year, 2))
+
+dt_f <- data_idn |>
+  fgroup_by(cache_id, cpi_data_level, ppp_data_level,
+            gdp_data_level, pce_data_level,
+            pop_data_level, reporting_level, 
+            imputation_id)|> 
+  collapg(custom = list(fmean = c(survey_mean_lcu = "welfare")), w = weight)|>
+  fgroup_by(cache_id, cpi_data_level, ppp_data_level,
+            gdp_data_level, pce_data_level,
+            pop_data_level, reporting_level)|>
+  collapg(custom = list(fmean = c(survey_mean_lcu = "survey_mean_lcu")), w = weight)|>
+  fungroup()
+
+md_level_idn <- data_idn[, as.list(wrp_md_dist_stats(welfare = welfare_ppp,
+                                weight  = weight,
+                                mean = NULL)),
+    by = .(cache_id, cpi_data_level, ppp_data_level,
+           gdp_data_level, pce_data_level,
+           pop_data_level, reporting_level,imputation_id)]|>
+  fgroup_by(cache_id, cpi_data_level, ppp_data_level,
+            gdp_data_level, pce_data_level,
+            pop_data_level, reporting_level)|>
+  collapg(fmean, cols = c("mean","median","gini",
+                          "polarization","mld",
+                          paste0("decile",1:10)))|>
+  fungroup()
+
+dt_meta_vars <- dt |>
+  fsubset(country_code == "IDN")|>
+  get_vars(metadata_vars) |> 
+  funique(cols = c("cache_id", "cpi_data_level", "ppp_data_level",
+                   "gdp_data_level", "pce_data_level",
+                   "pop_data_level", "reporting_level")) 
+
+add_vars(md_level_idn) <- dt_meta_vars|>
+  fselect(-c(cache_id, cpi_data_level, ppp_data_level,
+             gdp_data_level, pce_data_level,
+             pop_data_level, reporting_level))
+
+md_level_idn <- md_level_idn|>
+  joyn::joyn(dt_f, 
+             by = c("cache_id", "cpi_data_level", 
+                    "ppp_data_level", "gdp_data_level",
+                    "pce_data_level", "pop_data_level", 
+                    "reporting_level"),
+             match_type = "1:1",
+             y_vars_to_keep = c("survey_mean_lcu"))|>
+  fsubset(.joyn != "y")|>
+  fselect(-c(.joyn))|>
+  joyn::joyn(dl_aux$cpi|> 
+                     fselect(country_code, 
+                             survey_year, 
+                             survey_acronym,
+                             cpi_data_level, 
+                             cpi),
+                   by = c(
+                     "country_code", "survey_year",
+                     "survey_acronym", "cpi_data_level"
+                   ),
+                   match_type = "m:1",
+             y_vars_to_keep = c("cpi"))|>
+  fsubset(.joyn != "y")|>
+  fselect(-.joyn)|>
+  joyn::joyn(dl_aux$ppp|>
+                     fsubset(ppp_default == TRUE)|> # Select default PPP values
+                     fselect(country_code,
+                             ppp_data_level,
+                             ppp),
+                   by = c("country_code", "ppp_data_level"),
+                   match_type = "m:1",
+             y_vars_to_keep = c("ppp"))|>
+  fsubset(.joyn != "y")|>
+  fselect(-.joyn)|>
+  fmutate(survey_mean_ppp = survey_mean_lcu / ppp / cpi)
+
+
+waldo::compare(md_level_idn$mean, md_level_idn$survey_mean_ppp, tolerance = 1e-6)
 ```

--- a/replex_welfare_ppp.qmd
+++ b/replex_welfare_ppp.qmd
@@ -1,0 +1,187 @@
+---
+title: "Replex: Mean Welfare PPP"
+format: 
+  html:
+    code-fold: true
+execute:
+  cache: true
+---
+
+## Issue to solve
+
+**Problem:** When we calculate the welfare mean separately than through the `wbpip` function leads to different survey distributional estimations.
+
+**Assumption**: The following identity should work:
+
+$$[\frac{\sum{x*w}}{N}]/ppp/cpi == \frac{\sum{(x/ppp/cpi)*w}}{N}$$
+
+
+where $x$ is welfare, $w$ is weights, $N$ is number of observations and $ppp$ and $cpi$ are unique per survey.
+
+::: {.callout-note}
+Load `cache_tb` from master 
+:::
+
+## Error
+
+**Objective**: We show how the identity does not hold using our code.
+
+First, we calculate the mean of welfare ($\frac{\sum{x*w}}{N}$): 
+
+```{r}
+#| echo: true
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Generate means separately   ---------
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+dt <- cache_tb |>
+  fselect(welfare, welfare_ppp, weight, survey_id, cache_id, country_code, 
+            surveyid_year, survey_acronym, survey_year, welfare_type,
+            distribution_type, gd_type, imputation_id, cpi_data_level, 
+            ppp_data_level, gdp_data_level, pce_data_level, 
+            pop_data_level, reporting_level, area)|>
+  fsubset(distribution_type %in% c("imputed", "micro"))
+
+dt_c <- dt |>
+  fgroup_by(cache_id, cpi_data_level, ppp_data_level,
+            gdp_data_level, pce_data_level,
+            pop_data_level, reporting_level, 
+            imputation_id)|> 
+  collapg(custom = list(fmean = c(survey_mean_lcu = "welfare")), w = weight)|>
+  fgroup_by(cache_id, cpi_data_level, ppp_data_level,
+            gdp_data_level, pce_data_level,
+            pop_data_level, reporting_level)|>
+  collapg(custom = list(fmean = c(survey_mean_lcu = "survey_mean_lcu")), w = weight)|>
+  fungroup()
+
+# Select variables for metadata
+metadata_vars <- c("cache_id", "reporting_level", "area",
+                   "survey_id", "country_code", "surveyid_year", 
+                   "survey_acronym","survey_year", "welfare_type", 
+                   "distribution_type","gd_type","cpi_data_level",
+                   "ppp_data_level", "gdp_data_level", 
+                   "pce_data_level", "pop_data_level")
+
+dt_meta_vars <- dt |>
+  get_vars(metadata_vars) |> 
+  funique(cols = c("cache_id", "cpi_data_level", "ppp_data_level",
+                   "gdp_data_level", "pce_data_level",
+                   "pop_data_level", "reporting_level")) 
+
+add_vars(dt_c) <- dt_meta_vars|>
+  fselect(-c(cache_id, cpi_data_level, ppp_data_level,
+             gdp_data_level, pce_data_level,
+             pop_data_level, reporting_level))
+
+rm(dt_meta_vars)
+```
+
+Second, we merge ppp and cpi tables and calculate the PPP mean:
+
+```{r}
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Join ppp and cpi   ---------
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  #--------- Merge with CPI ---------
+  
+  # Merge survey table with CPI (left join)
+  dt_j <- joyn::joyn(dt_c, dl_aux$cpi|> 
+                     fselect(country_code, 
+                             survey_year, 
+                             survey_acronym,
+                             cpi_data_level, 
+                             cpi),
+                   by = c(
+                     "country_code", "survey_year",
+                     "survey_acronym", "cpi_data_level"
+                   ),
+                   match_type = "m:1"
+  )
+  
+  if (nrow(dt_j[.joyn == "x"]) > 0) {
+    msg <- "We should not have NOT-matching observations from survey-mean tables"
+    hint <- "Make sure CPI table is up to date"
+    rlang::abort(c(
+      msg,
+      i = hint
+    ),
+    class = "pipdm_error"
+    )
+  }
+  
+  dt_j <- dt_j|>
+    fsubset(.joyn != "y")|>
+    fselect(-.joyn)
+  
+  #--------- Merge with PPP ---------
+  
+  # Merge survey table with PPP (left join)
+  dt_j <- joyn::joyn(dt_j, dl_aux$ppp|>
+                     fsubset(ppp_default == TRUE)|> # Select default PPP values
+                     fselect(country_code,
+                             ppp_data_level,
+                             ppp),
+                   by = c("country_code", "ppp_data_level"),
+                   match_type = "m:1"
+  )
+  
+  if (nrow(dt_j[.joyn == "x"]) > 0) {
+    msg <- "We should not have NOT-matching observations from survey-mean tables"
+    hint <- "Make sure PPP table is up to date"
+    rlang::abort(c(
+      msg,
+      i = hint
+    ),
+    class = "pipdm_error"
+    )
+  }
+  
+  dt_j <- dt_j |>
+    fsubset(.joyn != "y")|>
+    fselect(-.joyn)
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Calculate mean_ppp   ---------
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  
+dt_f <- fmutate(dt_j, survey_mean_ppp = survey_mean_lcu / ppp / cpi)
+
+rm(dt_c, dt_j)
+
+```
+
+This results should be the same as if we calculate the mean using the `wbpip` function over `welfare_ppp`:
+
+```{r}
+source("wrp_wbpip.R")
+
+md_level <- dt |>
+  _[, as.list(wrp_md_dist_stats(welfare = welfare_ppp,
+                                weight  = weight,
+                                mean = NULL)),
+    by = .(cache_id, imputation_id, cpi_data_level, ppp_data_level,
+           gdp_data_level, pce_data_level,
+           pop_data_level, reporting_level)]|>
+  fgroup_by(cache_id, cpi_data_level, ppp_data_level,
+            gdp_data_level, pce_data_level,
+            pop_data_level, reporting_level)|>
+  collapg(fmean, cols = c("mean","median","gini",
+                          "polarization","mld",
+                          paste0("decile",1:10)))|>
+  fungroup()|>
+  joyn::joyn(dt_f, 
+             by = c("cache_id", "cpi_data_level", 
+                    "ppp_data_level", "gdp_data_level",
+                    "pce_data_level", "pop_data_level", 
+                    "reporting_level"),
+             match_type = "1:1",
+             y_vars_to_keep = "survey_mean_ppp")
+
+
+waldo::compare(md_level$mean, md_level$survey_mean_ppp, tolerance = 1e-7)
+
+```
+

--- a/replex_welfare_ppp.qmd
+++ b/replex_welfare_ppp.qmd
@@ -387,3 +387,110 @@ md_level_idn <- md_level_idn|>
 
 waldo::compare(md_level_idn$mean, md_level_idn$survey_mean_ppp, tolerance = 1e-6)
 ```
+
+
+4. Test if using the `cpi` and `ppp` from cache works (success!)
+
+
+```{r}
+data_idn <- cache_tb|>
+  fsubset(country_code == "IDN" & distribution_type %in% c("imputed", "micro"))|>
+  fselect(welfare, welfare_ppp, welfare_lcu, cpi, ppp,
+          weight, survey_id, cache_id, country_code, 
+          surveyid_year, survey_acronym, survey_year, welfare_type,
+          distribution_type, gd_type, imputation_id, cpi_data_level, 
+          ppp_data_level, gdp_data_level, pce_data_level, 
+          pop_data_level, reporting_level)
+
+dt_f <- data_idn |>
+  fgroup_by(cache_id, cpi_data_level, ppp_data_level,
+            gdp_data_level, pce_data_level,
+            pop_data_level, reporting_level, 
+            imputation_id)|> 
+  collapg(custom = list(fmean = c(survey_mean_lcu = "welfare")), w = weight)|>
+  fgroup_by(cache_id, cpi_data_level, ppp_data_level,
+            gdp_data_level, pce_data_level,
+            pop_data_level, reporting_level)|>
+  collapg(custom = list(fmean = c(survey_mean_lcu = "survey_mean_lcu")), w = weight)|>
+  fungroup()
+
+md_level_idn <- data_idn[, as.list(wrp_md_dist_stats(welfare = welfare_ppp,
+                                weight  = weight,
+                                mean = NULL)),
+    by = .(cache_id, cpi_data_level, ppp_data_level,
+           gdp_data_level, pce_data_level,
+           pop_data_level, reporting_level,imputation_id)]|>
+  fgroup_by(cache_id, cpi_data_level, ppp_data_level,
+            gdp_data_level, pce_data_level,
+            pop_data_level, reporting_level)|>
+  collapg(fmean, cols = c("mean","median","gini",
+                          "polarization","mld",
+                          paste0("decile",1:10)))|>
+  fungroup()
+
+metadata_vars <- c("cache_id", "reporting_level", "cpi","ppp",
+                   "survey_id", "country_code", "surveyid_year", 
+                   "survey_acronym","survey_year", "welfare_type", 
+                   "distribution_type","gd_type","cpi_data_level",
+                   "ppp_data_level", "gdp_data_level", 
+                   "pce_data_level", "pop_data_level")
+
+dt_meta_vars <- data_idn |>
+  get_vars(metadata_vars) |> 
+  funique(cols = c("cache_id", "cpi_data_level", "ppp_data_level",
+                   "gdp_data_level", "pce_data_level",
+                   "pop_data_level", "reporting_level")) 
+
+add_vars(md_level_idn) <- dt_meta_vars|>
+  fselect(-c(cache_id, cpi_data_level, ppp_data_level,
+             gdp_data_level, pce_data_level,
+             pop_data_level, reporting_level))
+
+md_level_idn <- md_level_idn|>
+  joyn::joyn(dt_f, 
+             by = c("cache_id", "cpi_data_level", 
+                    "ppp_data_level", "gdp_data_level",
+                    "pce_data_level", "pop_data_level", 
+                    "reporting_level"),
+             match_type = "1:1",
+             y_vars_to_keep = c("survey_mean_lcu"))|>
+  fmutate(survey_mean_ppp = survey_mean_lcu / ppp / cpi)
+
+
+waldo::compare(md_level_idn$mean, md_level_idn$survey_mean_ppp, tolerance = 1e-6)
+
+```
+
+Compare `cpi` and `ppp`
+
+```{r}
+md_level_idn2 <- md_level_idn |>
+  frename(cpi = "cpi_org",ppp = "ppp_org")|>
+  joyn::joyn(dl_aux$cpi|> 
+                     fselect(country_code, 
+                             survey_year, 
+                             survey_acronym,
+                             cpi_data_level, 
+                             cpi),
+                   by = c(
+                     "country_code", "survey_year",
+                     "survey_acronym", "cpi_data_level"
+                   ),
+                   match_type = "m:1",
+             y_vars_to_keep = c("cpi"))|>
+  fsubset(.joyn != "y")|>
+  fselect(-.joyn)|>
+  joyn::joyn(dl_aux$ppp|>
+                     fsubset(ppp_default == TRUE)|> # Select default PPP values
+                     fselect(country_code,
+                             ppp_data_level,
+                             ppp),
+                   by = c("country_code", "ppp_data_level"),
+                   match_type = "m:1",
+             y_vars_to_keep = c("ppp"))|>
+  fsubset(.joyn != "y")|>
+  fselect(-.joyn)
+
+waldo::compare(md_level_idn2$cpi_org, md_level_idn2$cpi, tolerance = 1e-6)
+waldo::compare(md_level_idn2$ppp_org, md_level_idn2$ppp, tolerance = 1e-6)
+```

--- a/replex_welfare_ppp.qmd
+++ b/replex_welfare_ppp.qmd
@@ -77,7 +77,7 @@ add_vars(dt_c) <- dt_meta_vars|>
 rm(dt_meta_vars)
 ```
 
-Second, we merge ppp and cpi tables and calculate the PPP mean:
+Second, we merge $ppp$ and $cpi$ tables and calculate the PPP mean:
 
 ```{r}
 
@@ -249,6 +249,7 @@ dist_obs <- data_idn |>
   fselect(welfare, welfare_ppp, weight, cpi, ppp)|>
   fndistinct()
 
+dist_obs
 ```
 
 2. The `welfare_ppp` vector can be different than `welfare_ppp/ppp/cpi` (yes, it is!)
@@ -257,12 +258,6 @@ dist_obs <- data_idn |>
 
 dt_tst <- data_idn|>
   fmutate(new_welf_ppp = welfare/ppp/cpi)
-
-# |>
-#   fmutate(diff = welfare_ppp-new_welf_ppp)|>
-#   fsubset(diff>1e-7)
-# 
-# dt_tst
 
 waldo::compare(dt_tst$welfare_ppp, dt_tst$new_welf_ppp)
 

--- a/replex_welfare_ppp.qmd
+++ b/replex_welfare_ppp.qmd
@@ -15,18 +15,17 @@ execute:
 
 $$[\frac{\sum{x*w}}{N}]/ppp/cpi == \frac{\sum{(x/ppp/cpi)*w}}{N}$$
 
-
 where $x$ is welfare, $w$ is weights, $N$ is number of observations and $ppp$ and $cpi$ are unique per survey.
 
-::: {.callout-note}
-Load `cache_tb` from master 
+::: callout-note
+Load `cache_tb` from master
 :::
 
 ## Error
 
 **Objective**: We show how the identity does not hold using our code.
 
-First, we calculate the mean of welfare ($\frac{\sum{x*w}}{N}$): 
+First, we calculate the mean of welfare ($\frac{\sum{x*w}}{N}$):
 
 ```{r}
 #| echo: true
@@ -34,6 +33,8 @@ First, we calculate the mean of welfare ($\frac{\sum{x*w}}{N}$):
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Generate means separately   ---------
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+rm(cache_ls)
 
 dt <- cache_tb |>
   fselect(welfare, welfare_ppp, weight, survey_id, cache_id, country_code, 
@@ -206,7 +207,7 @@ dt_error
 
 ## Test hypothesis
 
-1. The mismatch might be related to the unique values of $cpi$ and $ppp$ (Its not!).
+1.  The mismatch might be related to the unique values of $cpi$ and $ppp$ (Its not!).
 
 ```{r}
 
@@ -252,7 +253,7 @@ dist_obs <- data_idn |>
 dist_obs
 ```
 
-2. The `welfare_ppp` vector can be different than `welfare_ppp/ppp/cpi` (yes, it is!)
+2.  The `welfare_ppp` vector can be different than `welfare_ppp/ppp/cpi` (yes, it is!)
 
 ```{r}
 
@@ -260,5 +261,37 @@ dt_tst <- data_idn|>
   fmutate(new_welf_ppp = welfare_lcu/ppp/cpi)
 
 waldo::compare(dt_tst$welfare_ppp, dt_tst$new_welf_ppp)
+
+```
+
+3.  Check if it works using the new `welfare_ppp` vector.
+
+```{r}
+
+md_level_idn <- dt_tst[, as.list(wrp_md_dist_stats(welfare = new_welf_ppp,
+                                weight  = weight,
+                                mean = NULL)),
+    by = .(cache_id, cpi_data_level, ppp_data_level,
+           gdp_data_level, pce_data_level,
+           pop_data_level, reporting_level,imputation_id)]|>
+  fgroup_by(cache_id, cpi_data_level, ppp_data_level,
+            gdp_data_level, pce_data_level,
+            pop_data_level, reporting_level)|>
+  collapg(fmean, cols = c("mean","median","gini",
+                          "polarization","mld",
+                          paste0("decile",1:10)))|>
+  fungroup()|>
+  joyn::joyn(dt_f, 
+             by = c("cache_id", "cpi_data_level", 
+                    "ppp_data_level", "gdp_data_level",
+                    "pce_data_level", "pop_data_level", 
+                    "reporting_level"),
+             match_type = "1:1",
+             y_vars_to_keep = c("survey_mean_ppp", "ppp","cpi"))|>
+  fsubset(.joyn != "y")|>
+  fselect(-c(.joyn))
+
+
+waldo::compare(md_level_idn$mean, md_level_idn$survey_mean_ppp, tolerance = 1e-6)
 
 ```

--- a/replex_welfare_ppp.qmd
+++ b/replex_welfare_ppp.qmd
@@ -158,8 +158,7 @@ This results should be the same as if we calculate the mean using the `wbpip` fu
 ```{r}
 source("wrp_wbpip.R")
 
-md_level <- dt |>
-  _[, as.list(wrp_md_dist_stats(welfare = welfare_ppp,
+md_level <- dt[, as.list(wrp_md_dist_stats(welfare = welfare_ppp,
                                 weight  = weight,
                                 mean = NULL)),
     by = .(cache_id, imputation_id, cpi_data_level, ppp_data_level,
@@ -178,10 +177,29 @@ md_level <- dt |>
                     "pce_data_level", "pop_data_level", 
                     "reporting_level"),
              match_type = "1:1",
-             y_vars_to_keep = "survey_mean_ppp")
+             y_vars_to_keep = "survey_mean_ppp")|>
+  fselect(-c(.joyn))
 
 
-waldo::compare(md_level$mean, md_level$survey_mean_ppp, tolerance = 1e-7)
+waldo::compare(md_level$mean, md_level$survey_mean_ppp, tolerance = 1e-6)
 
 ```
 
+## Find problematic observations
+
+```{r}
+
+spl_cache <- as.data.frame(matrix(unlist(strsplit(md_level$cache_id, "_")),ncol=6,byrow=T))
+
+names(spl_cache) <- c("country", "year", "survey", "D...","w_type", "source")
+
+dt_all <- cbind(md_level, spl_cache)
+
+dt_error <- dt_all[survey_mean_ppp!=mean,-c("median","gini",
+                          "polarization","mld",
+                          paste0("decile",1:10))]|>
+  fmutate(diff = survey_mean_ppp-mean)|>
+  fsubset(diff>1e-7)
+
+dt_error
+```

--- a/replex_welfare_ppp.qmd
+++ b/replex_welfare_ppp.qmd
@@ -177,7 +177,7 @@ md_level <- dt[, as.list(wrp_md_dist_stats(welfare = welfare_ppp,
                     "pce_data_level", "pop_data_level", 
                     "reporting_level"),
              match_type = "1:1",
-             y_vars_to_keep = "survey_mean_ppp")|>
+             y_vars_to_keep = c("survey_mean_ppp", "ppp","cpi"))|>
   fselect(-c(.joyn))
 
 
@@ -202,4 +202,68 @@ dt_error <- dt_all[survey_mean_ppp!=mean,-c("median","gini",
   fsubset(diff>1e-7)
 
 dt_error
+```
+
+## Test hypothesis
+
+1. The mismatch might be related to the unique values of $cpi$ and $ppp$ (Its not!).
+
+```{r}
+
+data_idn <- cache_tb|>
+  fsubset(country_code == "IDN" & distribution_type %in% c("imputed", "micro"))|>
+  fselect(welfare, welfare_ppp, weight, survey_id, cache_id, country_code, 
+            surveyid_year, survey_acronym, survey_year, welfare_type,
+            distribution_type, gd_type, imputation_id, cpi_data_level, 
+            ppp_data_level, gdp_data_level, pce_data_level, 
+            pop_data_level, reporting_level)|>
+  joyn::joyn(dl_aux$cpi|> 
+                     fselect(country_code, 
+                             survey_year, 
+                             survey_acronym,
+                             cpi_data_level, 
+                             cpi),
+                   by = c(
+                     "country_code", "survey_year",
+                     "survey_acronym", "cpi_data_level"
+                   ),
+                   match_type = "m:1"
+  )|>
+  fsubset(.joyn != "y")|>
+  fselect(-.joyn)|>
+  joyn::joyn(dl_aux$ppp|>
+                     fsubset(ppp_default == TRUE)|> # Select default PPP values
+                     fselect(country_code,
+                             ppp_data_level,
+                             ppp),
+                   by = c("country_code", "ppp_data_level"),
+                   match_type = "m:1"
+  )|>
+  fsubset(.joyn != "y")|>
+  fselect(-.joyn)
+
+dist_obs <- data_idn |>
+  fgroup_by(cache_id, cpi_data_level,ppp_data_level, 
+            gdp_data_level, pce_data_level,
+            pop_data_level, reporting_level)|>
+  fselect(welfare, welfare_ppp, weight, cpi, ppp)|>
+  fndistinct()
+
+```
+
+2. The `welfare_ppp` vector can be different than `welfare_ppp/ppp/cpi` (yes, it is!)
+
+```{r}
+
+dt_tst <- data_idn|>
+  fmutate(new_welf_ppp = welfare/ppp/cpi)
+
+# |>
+#   fmutate(diff = welfare_ppp-new_welf_ppp)|>
+#   fsubset(diff>1e-7)
+# 
+# dt_tst
+
+waldo::compare(dt_tst$welfare_ppp, dt_tst$new_welf_ppp)
+
 ```

--- a/replex_welfare_ppp.qmd
+++ b/replex_welfare_ppp.qmd
@@ -212,7 +212,7 @@ dt_error
 
 data_idn <- cache_tb|>
   fsubset(country_code == "IDN" & distribution_type %in% c("imputed", "micro"))|>
-  fselect(welfare, welfare_ppp, weight, survey_id, cache_id, country_code, 
+  fselect(welfare, welfare_ppp, welfare_lcu,weight, survey_id, cache_id, country_code, 
             surveyid_year, survey_acronym, survey_year, welfare_type,
             distribution_type, gd_type, imputation_id, cpi_data_level, 
             ppp_data_level, gdp_data_level, pce_data_level, 
@@ -246,7 +246,7 @@ dist_obs <- data_idn |>
   fgroup_by(cache_id, cpi_data_level,ppp_data_level, 
             gdp_data_level, pce_data_level,
             pop_data_level, reporting_level)|>
-  fselect(welfare, welfare_ppp, weight, cpi, ppp)|>
+  fselect(welfare_lcu, welfare, welfare_ppp, weight, cpi, ppp)|>
   fndistinct()
 
 dist_obs
@@ -257,7 +257,7 @@ dist_obs
 ```{r}
 
 dt_tst <- data_idn|>
-  fmutate(new_welf_ppp = welfare/ppp/cpi)
+  fmutate(new_welf_ppp = welfare_lcu/ppp/cpi)
 
 waldo::compare(dt_tst$welfare_ppp, dt_tst$new_welf_ppp)
 


### PR DESCRIPTION
Changes to fix issue of merging wrong cpi and ppp (old version). 
1. We use the ppp and cpi from cache.
2. These changes make `survey_mean_ppp` different from the one calculated in the old survey_means file (but it is consistent with the wefare_ppp vector in cache)
3. The dist_stats does not attach the survey_means for micro or imputed data.

The tests for replication only use the observations where ppp/cpi are the same in cache and in the aux file. 